### PR TITLE
Empty filename and offset in CDX index response

### DIFF
--- a/pkg/server/warcserver/indexhandler.go
+++ b/pkg/server/warcserver/indexhandler.go
@@ -105,8 +105,8 @@ func cdxjTopywbJson(record *cdx.Cdx) *pywbJson {
 		Status:    record.Hsc,
 		Digest:    record.Sha,
 		Length:    record.Rle,
-		Offset:    record.Ref,
-		Filename:  record.Ref,
+		Offset:    "",
+		Filename:  "",
 	}
 	return js
 }


### PR DESCRIPTION
pywb 2.4.x added a check that inhibits loading resource from gowarc when filename and/or offset is present in index response: https://github.com/webrecorder/pywb/blob/54d8bccf4a4eebf305012d49cb7330eaddea9eba/pywb/warcserver/resource/responseloader.py#L286