### PR TITLE
rename utils to primitiveextension

### DIFF
--- a/cmd/warc/cmd/cat/cat.go
+++ b/cmd/warc/cmd/cat/cat.go
@@ -24,12 +24,11 @@ import (
 	"sort"
 	"strconv"
 
-	"github.com/nlnwa/gowarc/pkg/utils"
+	ext "github.com/nlnwa/gowarc/pkg/primitiveextension"
 	"github.com/nlnwa/gowarc/warcoptions"
 	"github.com/nlnwa/gowarc/warcreader"
 	"github.com/nlnwa/gowarc/warcrecord"
 	"github.com/nlnwa/gowarc/warcwriter"
-
 	"github.com/spf13/cobra"
 )
 
@@ -102,7 +101,7 @@ func readFile(c *conf, fileName string) {
 			break
 		}
 		if len(c.id) > 0 {
-			if !utils.Contains(c.id, wr.WarcHeader().Get(warcrecord.WarcRecordID)) {
+			if !ext.Contains(c.id, wr.WarcHeader().Get(warcrecord.WarcRecordID)) {
 				continue
 			}
 		}

--- a/cmd/warc/cmd/ls/ls.go
+++ b/cmd/warc/cmd/ls/ls.go
@@ -23,7 +23,7 @@ import (
 	"sort"
 	"strconv"
 
-	"github.com/nlnwa/gowarc/pkg/utils"
+	ext "github.com/nlnwa/gowarc/pkg/primitiveextension"
 	"github.com/nlnwa/gowarc/warcoptions"
 	"github.com/nlnwa/gowarc/warcreader"
 	"github.com/nlnwa/gowarc/warcrecord"
@@ -93,7 +93,7 @@ func readFile(c *conf, fileName string) {
 			break
 		}
 		if len(c.id) > 0 {
-			if !utils.Contains(c.id, wr.WarcHeader().Get(warcrecord.WarcRecordID)) {
+			if !ext.Contains(c.id, wr.WarcHeader().Get(warcrecord.WarcRecordID)) {
 				continue
 			}
 		}
@@ -110,6 +110,6 @@ func readFile(c *conf, fileName string) {
 
 func printRecord(offset int64, record warcrecord.WarcRecord) {
 	recordID := record.WarcHeader().Get(warcrecord.WarcRecordID)
-	targetURI := utils.CropString(record.WarcHeader().Get(warcrecord.WarcTargetURI), 100)
+	targetURI := ext.CropString(record.WarcHeader().Get(warcrecord.WarcTargetURI), 100)
 	fmt.Printf("%v\t%s\t%s \t%s\n", offset, recordID, record.Type(), targetURI)
 }

--- a/cmd/warc/cmd/root.go
+++ b/cmd/warc/cmd/root.go
@@ -21,9 +21,7 @@ import (
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/nlnwa/gowarc/cmd/warc/cmd/cat"
-	"github.com/nlnwa/gowarc/cmd/warc/cmd/index"
 	"github.com/nlnwa/gowarc/cmd/warc/cmd/ls"
-	"github.com/nlnwa/gowarc/cmd/warc/cmd/serve"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -71,8 +69,6 @@ func NewCommand() *cobra.Command {
 	// Subcommands
 	cmd.AddCommand(ls.NewCommand())
 	cmd.AddCommand(cat.NewCommand())
-	cmd.AddCommand(serve.NewCommand())
-	cmd.AddCommand(index.NewCommand())
 
 	return cmd
 }

--- a/pkg/primitiveextension/primitiveextension.go
+++ b/pkg/primitiveextension/primitiveextension.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package utils
+package primitiveextension
 
 // Searches string array s from string e
 func Contains(s []string, e string) bool {

--- a/pkg/primitiveextension/primitiveextension_test.go
+++ b/pkg/primitiveextension/primitiveextension_test.go
@@ -1,16 +1,16 @@
-package utils_test
+package primitiveextension_test
 
 import (
 	"testing"
 
-	"github.com/nlnwa/gowarc/pkg/utils"
+	ext "github.com/nlnwa/gowarc/pkg/primitiveextension"
 )
 
 func TestContainsMatchOnMatching(t *testing.T) {
 	needle := "needle"
 	haystack := []string{"hay1", "hay2", needle, "hay3", "hay5"}
 
-	if !utils.Contains(haystack, needle) {
+	if !ext.Contains(haystack, needle) {
 		t.Error("Failed to find needle")
 	}
 }
@@ -19,7 +19,7 @@ func TestContainsNonMatchOnNonMatching(t *testing.T) {
 	needle := "needle"
 	haystack := []string{"hay1", "hay2", "hay4", "hay3", "hay5"}
 
-	if utils.Contains(haystack, needle) {
+	if ext.Contains(haystack, needle) {
 		t.Error("Found element that does not exist in slice")
 	}
 }
@@ -28,7 +28,7 @@ func TestCropStringCrops(t *testing.T) {
 	input := "123456789"
 	expected := "12..."
 
-	actual := utils.CropString(input, 5)
+	actual := ext.CropString(input, 5)
 
 	if actual != expected {
 		t.Errorf("Expected %s got %s", expected, actual)
@@ -37,7 +37,7 @@ func TestCropStringCrops(t *testing.T) {
 
 func TestAbsInt64NegativeInput(t *testing.T) {
 	const input int64 = -10
-	actual := utils.AbsInt64(input)
+	actual := ext.AbsInt64(input)
 
 	const expected int64 = 10
 	if actual != expected {
@@ -47,7 +47,7 @@ func TestAbsInt64NegativeInput(t *testing.T) {
 
 func TestAbsInt64PositiveInput(t *testing.T) {
 	const input int64 = 10
-	actual := utils.AbsInt64(input)
+	actual := ext.AbsInt64(input)
 
 	const expected int64 = 10
 	if actual != expected {

--- a/pkg/server/warcserver/sorter.go
+++ b/pkg/server/warcserver/sorter.go
@@ -22,8 +22,9 @@ import (
 	"strings"
 
 	"github.com/dgraph-io/badger/v2"
+	"github.com/nlnwa/gowarc/pkg/primitiveextension"
+	ext "github.com/nlnwa/gowarc/pkg/primitiveextension"
 	"github.com/nlnwa/gowarc/pkg/timestamp"
-	"github.com/nlnwa/gowarc/pkg/utils"
 )
 
 type sorter struct {
@@ -81,6 +82,6 @@ func (s *sorter) sort() {
 	sort.Slice(s.values, func(i, j int) bool {
 		ts1 := s.values[i][0].(int64)
 		ts2 := s.values[j][0].(int64)
-		return utils.AbsInt64(closestTs-ts1) < utils.AbsInt64(closestTs-ts2)
+		return primitiveextension.AbsInt64(closestTs-ts1) < ext.AbsInt64(closestTs-ts2)
 	})
 }


### PR DESCRIPTION
Naming a package something generic i.e ``utils`` is bad practice. This PR renames the utils package (which I named 😅) to ``primitiveextension`` as the package contains helper functions for primitive types.