### PR TITLE
#39: avoid panic with invalid resolve

### DIFF
--- a/pkg/server/warcserver/resourcehandler.go
+++ b/pkg/server/warcserver/resourcehandler.go
@@ -20,6 +20,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
 	"github.com/dgraph-io/badger/v2"
 	"github.com/nlnwa/gowarc/pkg/index"
 	"github.com/nlnwa/gowarc/pkg/loader"
@@ -27,9 +31,6 @@ import (
 	"github.com/nlnwa/gowarc/warcoptions"
 	"github.com/nlnwa/gowarc/warcrecord"
 	"github.com/nlnwa/gowarc/warcwriter"
-	"io"
-	"net/http"
-	"strings"
 )
 
 type resourceHandler struct {

--- a/warcrecord/revisitblock.go
+++ b/warcrecord/revisitblock.go
@@ -20,10 +20,11 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"io"
 	"net/http"
 	"sync"
+
+	log "github.com/sirupsen/logrus"
 )
 
 const CRLF = "\r\n"
@@ -138,8 +139,16 @@ func Merge(revisit, refersTo WarcRecord) (WarcRecord, error) {
 	m.headers.Delete(WarcRefersToDate)
 	m.headers.Delete(WarcProfile)
 
-	b := m.block.(*RevisitBlock)
-	d := refersTo.Block().(PayloadBlock)
+	b, ok := m.block.(*RevisitBlock)
+	if !ok {
+		return nil, fmt.Errorf("revisit block is not of type RevisitBlock")
+	}
+
+	d, ok := refersTo.Block().(PayloadBlock)
+	if !ok {
+		return nil, fmt.Errorf("referer is not of type PayloadBlock")
+	}
+
 	b.data, err = d.PayloadBytes()
 	if err != nil {
 		log.Warnf("Merge err2: %v", err)


### PR DESCRIPTION
This patch is a minor fix to avoid panicking when resolve blocks have unexpected type
The fix is primitive in nature as gowarc is currently being refactored so this specific patch should not be needed in the upcoming release