### PR TITLE
Digest encoding

### DIFF
--- a/block_test.go
+++ b/block_test.go
@@ -47,7 +47,7 @@ func Test_genericBlock_BlockDigest(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			d, err := newDigest("sha1")
+			d, err := newDigest("sha1", Base16)
 			require.NoError(t, err)
 			block := newGenericBlock(&warcRecordOptions{}, tt.data, d)
 
@@ -76,7 +76,7 @@ func Test_genericBlock_Cache(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			d, err := newDigest("sha1")
+			d, err := newDigest("sha1", Base16)
 			require.NoError(t, err)
 			block := newGenericBlock(&warcRecordOptions{}, tt.data, d)
 
@@ -107,7 +107,7 @@ func Test_genericBlock_IsCached(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			d, err := newDigest("sha1")
+			d, err := newDigest("sha1", Base16)
 			require.NoError(t, err)
 			block := newGenericBlock(&warcRecordOptions{}, tt.data, d)
 
@@ -140,7 +140,7 @@ func Test_genericBlock_RawBytes(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			d, err := newDigest("sha1")
+			d, err := newDigest("sha1", Base16)
 			require.NoError(t, err)
 			block := newGenericBlock(&warcRecordOptions{}, tt.data, d)
 
@@ -169,7 +169,7 @@ func Test_warcfieldsBlock_BlockDigest(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			d, err := newDigest("sha1")
+			d, err := newDigest("sha1", Base16)
 			require.NoError(t, err)
 			validation := &Validation{}
 			o := defaultWarcRecordOptions()
@@ -202,7 +202,7 @@ func Test_warcfieldsBlock_Cache(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			d, err := newDigest("sha1")
+			d, err := newDigest("sha1", Base16)
 			require.NoError(t, err)
 			validation := &Validation{}
 			o := defaultWarcRecordOptions()
@@ -237,7 +237,7 @@ func Test_warcfieldsBlock_IsCached(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			d, err := newDigest("sha1")
+			d, err := newDigest("sha1", Base16)
 			require.NoError(t, err)
 			validation := &Validation{}
 			o := defaultWarcRecordOptions()
@@ -274,7 +274,7 @@ func Test_warcfieldsBlock_RawBytes(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			d, err := newDigest("sha1")
+			d, err := newDigest("sha1", Base16)
 			require.NoError(t, err)
 			validation := &Validation{}
 			o := defaultWarcRecordOptions()
@@ -313,9 +313,9 @@ func Test_httpRequestBlock_BlockDigest(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			blockDigest, err := newDigest("sha1")
+			blockDigest, err := newDigest("sha1", Base16)
 			require.NoError(t, err)
-			pDigest, err := newDigest("sha1")
+			pDigest, err := newDigest("sha1", Base16)
 			require.NoError(t, err)
 			block, err := newHttpBlock(&warcRecordOptions{}, tt.data, blockDigest, pDigest)
 			require.NoError(t, err)
@@ -351,9 +351,9 @@ func Test_httpRequestBlock_Cache(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			blockDigest, err := newDigest("sha1")
+			blockDigest, err := newDigest("sha1", Base16)
 			require.NoError(t, err)
-			pDigest, err := newDigest("sha1")
+			pDigest, err := newDigest("sha1", Base16)
 			require.NoError(t, err)
 			block, err := newHttpBlock(&warcRecordOptions{}, tt.data, blockDigest, pDigest)
 			require.NoError(t, err)
@@ -390,9 +390,9 @@ func Test_httpRequestBlock_IsCached(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			blockDigest, err := newDigest("sha1")
+			blockDigest, err := newDigest("sha1", Base16)
 			require.NoError(t, err)
-			pDigest, err := newDigest("sha1")
+			pDigest, err := newDigest("sha1", Base16)
 			require.NoError(t, err)
 			block, err := newHttpBlock(&warcRecordOptions{}, tt.data, blockDigest, pDigest)
 			require.NoError(t, err)
@@ -431,9 +431,9 @@ func Test_httpRequestBlock_RawBytes(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			blockDigest, err := newDigest("sha1")
+			blockDigest, err := newDigest("sha1", Base16)
 			require.NoError(t, err)
-			pDigest, err := newDigest("sha1")
+			pDigest, err := newDigest("sha1", Base16)
 			require.NoError(t, err)
 			block, err := newHttpBlock(&warcRecordOptions{}, tt.data, blockDigest, pDigest)
 			require.NoError(t, err)
@@ -466,9 +466,9 @@ func Test_httpResponseBlock_BlockDigest(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			blockDigest, err := newDigest("sha1")
+			blockDigest, err := newDigest("sha1", Base16)
 			require.NoError(t, err)
-			pDigest, err := newDigest("sha1")
+			pDigest, err := newDigest("sha1", Base16)
 			require.NoError(t, err)
 			block, err := newHttpBlock(&warcRecordOptions{}, tt.data, blockDigest, pDigest)
 			require.NoError(t, err)
@@ -501,9 +501,9 @@ func Test_httpResponseBlock_Cache(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			blockDigest, err := newDigest("sha1")
+			blockDigest, err := newDigest("sha1", Base16)
 			require.NoError(t, err)
-			pDigest, err := newDigest("sha1")
+			pDigest, err := newDigest("sha1", Base16)
 			require.NoError(t, err)
 			block, err := newHttpBlock(&warcRecordOptions{}, tt.data, blockDigest, pDigest)
 			require.NoError(t, err)
@@ -537,9 +537,9 @@ func Test_httpResponseBlock_IsCached(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			blockDigest, err := newDigest("sha1")
+			blockDigest, err := newDigest("sha1", Base16)
 			require.NoError(t, err)
-			pDigest, err := newDigest("sha1")
+			pDigest, err := newDigest("sha1", Base16)
 			require.NoError(t, err)
 			block, err := newHttpBlock(&warcRecordOptions{}, tt.data, blockDigest, pDigest)
 			require.NoError(t, err)
@@ -575,9 +575,9 @@ func Test_httpResponseBlock_RawBytes(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			blockDigest, err := newDigest("sha1")
+			blockDigest, err := newDigest("sha1", Base16)
 			require.NoError(t, err)
-			pDigest, err := newDigest("sha1")
+			pDigest, err := newDigest("sha1", Base16)
 			require.NoError(t, err)
 			block, err := newHttpBlock(&warcRecordOptions{}, tt.data, blockDigest, pDigest)
 			require.NoError(t, err)

--- a/digest.go
+++ b/digest.go
@@ -54,7 +54,7 @@ const (
 )
 
 func detectEncoding(algorithm, digest string, defaultEncoding digestEncoding) digestEncoding {
-	var algorithmLenght int
+	var algorithmLength int
 	switch algorithm {
 	case "md5":
 		if len(digest) == 32 {
@@ -66,20 +66,20 @@ func detectEncoding(algorithm, digest string, defaultEncoding digestEncoding) di
 				return Base16
 			}
 		}
-		algorithmLenght = md5.Size
+		algorithmLength = md5.Size
 	case "sha1":
-		algorithmLenght = sha1.Size
+		algorithmLength = sha1.Size
 	case "sha256":
-		algorithmLenght = sha256.Size
+		algorithmLength = sha256.Size
 	case "sha512":
-		algorithmLenght = sha512.Size
+		algorithmLength = sha512.Size
 	}
 	switch len(digest) {
-	case algorithmLenght * 2:
+	case algorithmLength * 2:
 		return Base16
-	case base32.StdEncoding.EncodedLen(algorithmLenght):
+	case base32.StdEncoding.EncodedLen(algorithmLength):
 		return Base32
-	case base64.StdEncoding.EncodedLen(algorithmLenght):
+	case base64.StdEncoding.EncodedLen(algorithmLength):
 		return Base64
 	}
 	return defaultEncoding

--- a/digest.go
+++ b/digest.go
@@ -109,7 +109,6 @@ func (d *digest) Sum(b []byte) []byte {
 
 func (d *digest) format() string {
 	return fmt.Sprintf("%s:%s", d.name, d.encoding.encode(d))
-	//return fmt.Sprintf("%s:%X", d.name, d.Sum(nil))
 }
 
 func (d *digest) validate() error {

--- a/digest.go
+++ b/digest.go
@@ -113,7 +113,7 @@ func (d *digest) format() string {
 }
 
 func (d *digest) validate() error {
-	computed := fmt.Sprintf("%s", d.encoding.encode(d))
+	computed := d.encoding.encode(d)
 	if d.hash != computed {
 		return fmt.Errorf("wrong digest: expected %s:%s, computed: %s:%s", d.name, d.hash, d.name, computed)
 	}

--- a/digest_test.go
+++ b/digest_test.go
@@ -23,27 +23,36 @@ import (
 
 func Test_newDigest(t *testing.T) {
 	tests := []struct {
-		name           string
-		algorithm      string
-		digestString   string
-		wantDigestName string
-		wantDigest     string
-		wantErr        bool
+		name            string
+		algorithm       string
+		digestString    string
+		defaultEncoding digestEncoding
+		wantDigestName  string
+		wantDigest      string
+		wantErr         bool
 	}{
-		{"md5", "md5", "Some content", "md5", "md5:B53227DA4280F0E18270F21DD77C91D0", false},
-		{"md5 with digest", "md5:12345", "Some content", "md5", "md5:B53227DA4280F0E18270F21DD77C91D0", false},
-		{"sha1", "sha1", "Some content", "sha1", "sha1:9F1A6ECF74E9F9B1AE52E8EB581D420E63E8453A", false},
-		{"sha1 with digest", "sha1:12345", "Some content", "sha1", "sha1:9F1A6ECF74E9F9B1AE52E8EB581D420E63E8453A", false},
-		{"sha256", "sha256", "Some content", "sha256", "sha256:9C6609FC5111405EA3F5BB3D1F6B5A5EFD19A0CEC53D85893FD96D265439CD5B", false},
-		{"sha256 with digest", "sha256:12345", "Some content", "sha256", "sha256:9C6609FC5111405EA3F5BB3D1F6B5A5EFD19A0CEC53D85893FD96D265439CD5B", false},
-		{"sha512", "sha512", "Some content", "sha512", "sha512:B20D977718ED67F2BF7620EE2D982FD850C4883EC8D048440FE7B6A86CF6322FD791C47B0C7469DBEEF3E339032E1ABC4BCEBE5EFC104BC19A117BFEF4478605", false},
-		{"sha512 with digest", "sha512:12345", "Some content", "sha512", "sha512:B20D977718ED67F2BF7620EE2D982FD850C4883EC8D048440FE7B6A86CF6322FD791C47B0C7469DBEEF3E339032E1ABC4BCEBE5EFC104BC19A117BFEF4478605", false},
-		{"unknown algorithm", "mysecret:12345", "Some content", "mysecret", "mysecret:123", true},
-		{"unknown algorithm with digest", "mysecret:12345", "Some content", "mysecret", "mysecret:123", true},
+		{"md5", "md5", "Some content", Base16, "md5", "md5:B53227DA4280F0E18270F21DD77C91D0", false},
+		{"md5 with base16 digest", "md5:12345", "Some content", Base16, "md5", "md5:B53227DA4280F0E18270F21DD77C91D0", false},
+		{"md5 with base32 digest", "md5:12345", "Some content", Base32, "md5", "md5:WUZCPWSCQDYODATQ6IO5O7ER2A======", false},
+		{"md5 with base64 digest", "md5:12345", "Some content", Base64, "md5", "md5:tTIn2kKA8OGCcPId13yR0A==", false},
+		{"sha1", "sha1", "Some content", Base16, "sha1", "sha1:9F1A6ECF74E9F9B1AE52E8EB581D420E63E8453A", false},
+		{"sha1 with base16 digest", "sha1:12345", "Some content", Base16, "sha1", "sha1:9F1A6ECF74E9F9B1AE52E8EB581D420E63E8453A", false},
+		{"sha1 with base32 digest", "sha1:12345", "Some content", Base32, "sha1", "sha1:T4NG5T3U5H43DLSS5DVVQHKCBZR6QRJ2", false},
+		{"sha1 with base64 digest", "sha1:12345", "Some content", Base64, "sha1", "sha1:nxpuz3Tp+bGuUujrWB1CDmPoRTo=", false},
+		{"sha256", "sha256", "Some content", Base16, "sha256", "sha256:9C6609FC5111405EA3F5BB3D1F6B5A5EFD19A0CEC53D85893FD96D265439CD5B", false},
+		{"sha256 with base16 digest", "sha256:12345", "Some content", Base16, "sha256", "sha256:9C6609FC5111405EA3F5BB3D1F6B5A5EFD19A0CEC53D85893FD96D265439CD5B", false},
+		{"sha256 with base32 digest", "sha256:12345", "Some content", Base32, "sha256", "sha256:TRTAT7CRCFAF5I7VXM6R6222L36RTIGOYU6YLCJ73FWSMVBZZVNQ====", false},
+		{"sha256 with base64 digest", "sha256:12345", "Some content", Base64, "sha256", "sha256:nGYJ/FERQF6j9bs9H2taXv0ZoM7FPYWJP9ltJlQ5zVs=", false},
+		{"sha512", "sha512", "Some content", Base16, "sha512", "sha512:B20D977718ED67F2BF7620EE2D982FD850C4883EC8D048440FE7B6A86CF6322FD791C47B0C7469DBEEF3E339032E1ABC4BCEBE5EFC104BC19A117BFEF4478605", false},
+		{"sha512 with base16 digest", "sha512:12345", "Some content", Base16, "sha512", "sha512:B20D977718ED67F2BF7620EE2D982FD850C4883EC8D048440FE7B6A86CF6322FD791C47B0C7469DBEEF3E339032E1ABC4BCEBE5EFC104BC19A117BFEF4478605", false},
+		{"sha512 with base32 digest", "sha512:12345", "Some content", Base32, "sha512", "sha512:WIGZO5YY5VT7FP3WEDXC3GBP3BIMJCB6ZDIEQRAP463KQ3HWGIX5PEOEPMGHI2O353Z6GOIDFYNLYS6OXZPPYECLYGNBC6766RDYMBI=", false},
+		{"sha512 with base64 digest", "sha512:12345", "Some content", Base64, "sha512", "sha512:sg2XdxjtZ/K/diDuLZgv2FDEiD7I0EhED+e2qGz2Mi/XkcR7DHRp2+7z4zkDLhq8S86+XvwQS8GaEXv+9EeGBQ==", false},
+		{"unknown algorithm", "mysecret:12345", "Some content", Base16, "mysecret", "mysecret:123", true},
+		{"unknown algorithm with digest", "mysecret:12345", "Some content", Base16, "mysecret", "mysecret:123", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			d, err := newDigest(tt.algorithm)
+			d, err := newDigest(tt.algorithm, tt.defaultEncoding)
 
 			assert := assert.New(t)
 			if tt.wantErr {
@@ -72,21 +81,29 @@ func Test_digest_validate(t *testing.T) {
 		wantValid    bool
 	}{
 		{"md5", "Some content", "md5", false},
-		{"md5 with digest", "Some content", "md5:B53227DA4280F0E18270F21DD77C91D0", true},
+		{"md5 with base16 digest", "Some content", "md5:B53227DA4280F0E18270F21DD77C91D0", true},
+		{"md5 with base32 digest", "Some content", "md5:WUZCPWSCQDYODATQ6IO5O7ER2A======", true},
+		{"md5 with base64 digest", "Some content", "md5:tTIn2kKA8OGCcPId13yR0A==", true},
 		{"md5 with wrong digest", "Some content", "md5:123", false},
 		{"sha1", "Some content", "sha1", false},
-		{"sha1 with digest", "Some content", "sha1:9F1A6ECF74E9F9B1AE52E8EB581D420E63E8453A", true},
+		{"sha1 with base16 digest", "Some content", "sha1:9F1A6ECF74E9F9B1AE52E8EB581D420E63E8453A", true},
+		{"sha1 with base32 digest", "Some content", "sha1:T4NG5T3U5H43DLSS5DVVQHKCBZR6QRJ2", true},
+		{"sha1 with base64 digest", "Some content", "sha1:nxpuz3Tp+bGuUujrWB1CDmPoRTo=", true},
 		{"sha1 with wrong digest", "Some content", "sha1:123", false},
 		{"sha256", "Some content", "sha256", false},
-		{"sha256 with digest", "Some content", "sha256:9C6609FC5111405EA3F5BB3D1F6B5A5EFD19A0CEC53D85893FD96D265439CD5B", true},
+		{"sha256 with base16 digest", "Some content", "sha256:9C6609FC5111405EA3F5BB3D1F6B5A5EFD19A0CEC53D85893FD96D265439CD5B", true},
+		{"sha256 with base32 digest", "Some content", "sha256:TRTAT7CRCFAF5I7VXM6R6222L36RTIGOYU6YLCJ73FWSMVBZZVNQ====", true},
+		{"sha256 with base64 digest", "Some content", "sha256:nGYJ/FERQF6j9bs9H2taXv0ZoM7FPYWJP9ltJlQ5zVs=", true},
 		{"sha256 with wrong digest", "Some content", "sha256:123", false},
 		{"sha512", "Some content", "sha512", false},
-		{"sha512 with digest", "Some content", "sha512:B20D977718ED67F2BF7620EE2D982FD850C4883EC8D048440FE7B6A86CF6322FD791C47B0C7469DBEEF3E339032E1ABC4BCEBE5EFC104BC19A117BFEF4478605", true},
+		{"sha512 with base16 digest", "Some content", "sha512:B20D977718ED67F2BF7620EE2D982FD850C4883EC8D048440FE7B6A86CF6322FD791C47B0C7469DBEEF3E339032E1ABC4BCEBE5EFC104BC19A117BFEF4478605", true},
+		{"sha512 with base32 digest", "Some content", "sha512:WIGZO5YY5VT7FP3WEDXC3GBP3BIMJCB6ZDIEQRAP463KQ3HWGIX5PEOEPMGHI2O353Z6GOIDFYNLYS6OXZPPYECLYGNBC6766RDYMBI=", true},
+		{"sha512 with base64 digest", "Some content", "sha512:sg2XdxjtZ/K/diDuLZgv2FDEiD7I0EhED+e2qGz2Mi/XkcR7DHRp2+7z4zkDLhq8S86+XvwQS8GaEXv+9EeGBQ==", true},
 		{"sha512 with wrong digest", "Some content", "sha512:123", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			d, _ := newDigest(tt.digestString)
+			d, _ := newDigest(tt.digestString, unknown)
 
 			assert := assert.New(t)
 			_, err := d.Write([]byte(tt.input))

--- a/options.go
+++ b/options.go
@@ -34,6 +34,7 @@ type warcRecordOptions struct {
 	fixContentLength        bool
 	fixDigest               bool
 	defaultDigestAlgorithm  string
+	defaultDigestEncoding   digestEncoding
 	bufferOptions           []diskbuffer.Option
 }
 
@@ -83,6 +84,7 @@ func defaultWarcRecordOptions() warcRecordOptions {
 		addMissingContentLength: true,
 		addMissingDigest:        true,
 		defaultDigestAlgorithm:  "sha1",
+		defaultDigestEncoding:   Base32,
 		fixContentLength:        true,
 		fixDigest:               true,
 	}
@@ -182,6 +184,17 @@ func WithAddMissingDigest(addMissingDigest bool) WarcRecordOption {
 func WithDefaultDigestAlgorithm(defaultDigestAlgorithm string) WarcRecordOption {
 	return newFuncWarcRecordOption(func(o *warcRecordOptions) {
 		o.defaultDigestAlgorithm = defaultDigestAlgorithm
+	})
+}
+
+// WithDefaultDigestEncoding sets which encoding to use for digest generation.
+//
+// Valid values: Base16, Base32 and Base64.
+//
+// defaults to Base32
+func WithDefaultDigestEncoding(defaultDigestEncoding digestEncoding) WarcRecordOption {
+	return newFuncWarcRecordOption(func(o *warcRecordOptions) {
+		o.defaultDigestEncoding = defaultDigestEncoding
 	})
 }
 

--- a/record_test.go
+++ b/record_test.go
@@ -419,7 +419,8 @@ func Test_warcRecord_Merge(t *testing.T) {
 
 func createRecord1(recordType RecordType, headers *WarcFields, data string) WarcRecord {
 	rb := NewRecordBuilder(recordType, WithSpecViolationPolicy(ErrFail), WithSyntaxErrorPolicy(ErrFail),
-		WithUnknownRecordTypePolicy(ErrIgnore), WithFixDigest(false), WithAddMissingDigest(false))
+		WithUnknownRecordTypePolicy(ErrIgnore), WithFixDigest(false), WithAddMissingDigest(false),
+		WithDefaultDigestEncoding(Base16))
 	for _, nv := range *headers {
 		rb.AddWarcHeader(nv.Name, nv.Value)
 	}

--- a/revisitblock.go
+++ b/revisitblock.go
@@ -88,7 +88,7 @@ func newRevisitBlock(opts *warcRecordOptions, src Block) (*revisitBlock, error) 
 		return nil, fmt.Errorf("making revisit of %T not supported", v)
 	}
 
-	blockDigest, _ := newDigest(block.opts.defaultDigestAlgorithm)
+	blockDigest, _ := newDigest(block.opts.defaultDigestAlgorithm, block.opts.defaultDigestEncoding)
 	if _, err := blockDigest.Write(block.headerBytes); err != nil {
 		return nil, err
 	}

--- a/warcfile_test.go
+++ b/warcfile_test.go
@@ -128,7 +128,8 @@ func TestWarcFileWriter_Write_warcinfo_uncompressed(t *testing.T) {
 		WithWarcInfoFunc(func(recordBuilder WarcRecordBuilder) error {
 			recordBuilder.AddWarcHeader(WarcRecordID, "<urn:uuid:4f271dba-fdfa-4915-ab7e-3e4e1fc0791b>")
 			return nil
-		}))
+		}),
+		WithRecordOptions(WithDefaultDigestEncoding(Base16)))
 	defer func() { assert.NoError(os.RemoveAll(testdir)) }()
 
 	// Write two records sequentially
@@ -170,7 +171,8 @@ func TestWarcFileWriter_Write_warcinfo_compressed(t *testing.T) {
 		WithWarcInfoFunc(func(recordBuilder WarcRecordBuilder) error {
 			recordBuilder.AddWarcHeader(WarcRecordID, "<urn:uuid:4f271dba-fdfa-4915-ab7e-3e4e1fc0791b>")
 			return nil
-		}))
+		}),
+		WithRecordOptions(WithDefaultDigestEncoding(Base16)))
 	defer func() { assert.NoError(os.RemoveAll(testdir)) }()
 
 	// Write two records sequentially


### PR DESCRIPTION
* Support for base16, base32 and base64 encoding of digests.
* Option for setting the default encoding to use for new digests.