### PR TITLE
Memory fix

### DIFF
--- a/httpblock.go
+++ b/httpblock.go
@@ -21,10 +21,11 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/nlnwa/gowarc/internal/diskbuffer"
 	"io"
 	"io/ioutil"
 	"net/http"
+
+	"github.com/nlnwa/gowarc/internal/diskbuffer"
 )
 
 type HttpRequestBlock interface {
@@ -338,7 +339,7 @@ func newHttpBlock(opts *warcRecordOptions, r io.Reader, blockDigest, payloadDige
 		rb = bufio.NewReader(r)
 	}
 
-	b, err := rb.Peek(4)
+	_, err := rb.Peek(4)
 	if err != nil {
 		return nil, fmt.Errorf("not a http block: %w", err)
 	}
@@ -364,7 +365,7 @@ func newHttpBlock(opts *warcRecordOptions, r io.Reader, blockDigest, payloadDige
 		payload = rb
 	}
 
-	if bytes.HasPrefix(b, []byte("HTTP")) {
+	if bytes.HasPrefix(hb, []byte("HTTP")) {
 		resp := &httpResponseBlock{
 			opts:            opts,
 			httpHeaderBytes: hb,

--- a/internal/diskbuffer/diskbuffer.go
+++ b/internal/diskbuffer/diskbuffer.go
@@ -249,7 +249,7 @@ func (b *buffer) Read(p []byte) (n int, err error) {
 	return n, err
 }
 
-// Peek returns the next n bytes without advancing the reader. The bytes stop being valid at the next read call.
+// Peek returns the next n bytes without advancing the reader.
 // If Peek returns fewer than n bytes, it also returns an error explaining why the read is short.
 // The error is ErrBufferFull if n is larger than b's buffer size.
 //


### PR DESCRIPTION
In the event that rb is set to bufio.NewReader the memory is not owned and therefore b buffer becomes invalid by the headerBytes function

Co signed by @maeb 