### PR TITLE
Improved error handling in warcfield parser

### DIFF
--- a/warcfieldsblock.go
+++ b/warcfieldsblock.go
@@ -93,7 +93,11 @@ func newWarcFieldsBlock(rb io.Reader, d *digest, validation *Validation, options
 		}
 	}
 	p := &warcfieldsParser{options}
-	wfb.warcFields, err = p.Parse(bufio.NewReader(bytes.NewReader(wfb.content)), validation, &position{})
+	blockValidation := Validation{}
+	wfb.warcFields, err = p.Parse(bufio.NewReader(bytes.NewReader(wfb.content)), &blockValidation, &position{})
+	for _, e := range blockValidation {
+		validation.addError(newWrappedSyntaxError("error in warc fields block", nil, e))
+	}
 
 	return wfb, err
 }

--- a/warcfieldsparser_test.go
+++ b/warcfieldsparser_test.go
@@ -302,7 +302,7 @@ func TestParseWarcFields(t *testing.T) {
 				assert.NoError(err)
 			}
 			assert.Equal(tt.want, got)
-			assert.Equal(tt.wantValidation, validation)
+			assert.Equal(tt.wantValidation, validation, "%s", validation.String())
 		})
 	}
 }


### PR DESCRIPTION
* Fixed an error where missing CR in last line in a warcfields-block didn't show up in validation report
* Errors in warcfields-block is now prefixed with "error in warc fields block" to distinguish them from errors in warc-header