### PR TITLE
New option to repair syntax errors in warcfields-blocks

### DIFF
--- a/block_test.go
+++ b/block_test.go
@@ -180,7 +180,7 @@ func Test_warcfieldsBlock_BlockDigest(t *testing.T) {
 			require.NoError(t, err)
 			validation := &Validation{}
 			o := defaultWarcRecordOptions()
-			block, err := newWarcFieldsBlock(tt.data, d, validation, &o)
+			block, err := newWarcFieldsBlock(&o, &WarcFields{}, tt.data, d, validation)
 			require.NoError(t, err)
 			require.True(t, validation.Valid(), validation)
 
@@ -221,7 +221,7 @@ func Test_warcfieldsBlock_Cache(t *testing.T) {
 			require.NoError(t, err)
 			validation := &Validation{}
 			o := defaultWarcRecordOptions()
-			block, err := newWarcFieldsBlock(tt.data, d, validation, &o)
+			block, err := newWarcFieldsBlock(&o, &WarcFields{}, tt.data, d, validation)
 			require.NoError(t, err)
 			if tt.wantCacheErr {
 				require.False(t, validation.Valid(), validation)
@@ -260,7 +260,7 @@ func Test_warcfieldsBlock_IsCached(t *testing.T) {
 			require.NoError(t, err)
 			validation := &Validation{}
 			o := defaultWarcRecordOptions()
-			block, err := newWarcFieldsBlock(tt.data, d, validation, &o)
+			block, err := newWarcFieldsBlock(&o, &WarcFields{}, tt.data, d, validation)
 			require.NoError(t, err)
 			require.True(t, validation.Valid(), validation)
 
@@ -297,7 +297,7 @@ func Test_warcfieldsBlock_RawBytes(t *testing.T) {
 			require.NoError(t, err)
 			validation := &Validation{}
 			o := defaultWarcRecordOptions()
-			block, err := newWarcFieldsBlock(tt.data, d, validation, &o)
+			block, err := newWarcFieldsBlock(&o, &WarcFields{}, tt.data, d, validation)
 			require.NoError(t, err)
 			require.True(t, validation.Valid(), validation)
 

--- a/block_test.go
+++ b/block_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 	"testing/iotest"
@@ -657,12 +656,12 @@ func validateCacheTest(t *testing.T, block Block, expectedContent string, expect
 	// Reading content twice should be ok
 	got, err := block.RawBytes()
 	require.NoError(t, err)
-	content, err := ioutil.ReadAll(got)
+	content, err := io.ReadAll(got)
 	require.NoError(t, err)
 	assert.Equal(t, expectedContent, string(content))
 	got, err = block.RawBytes()
 	require.NoError(t, err)
-	content, err = ioutil.ReadAll(got)
+	content, err = io.ReadAll(got)
 	require.NoError(t, err)
 	assert.Equal(t, expectedContent, string(content))
 
@@ -738,7 +737,7 @@ func validateRawBytesTest(t *testing.T, tt rawBytesTest, block Block, expectedCo
 		require.NoError(t, err)
 	}
 
-	content, err := ioutil.ReadAll(got)
+	content, err := io.ReadAll(got)
 	require.NoError(t, err)
 	assert.Equal(t, expectedContent, string(content))
 
@@ -747,7 +746,7 @@ func validateRawBytesTest(t *testing.T, tt rawBytesTest, block Block, expectedCo
 		got, err := block.RawBytes()
 		require.NoError(t, err)
 
-		content, err := ioutil.ReadAll(got)
+		content, err := io.ReadAll(got)
 		require.NoError(t, err)
 		assert.Equal(t, expectedContent, string(content))
 	} else {

--- a/digest.go
+++ b/digest.go
@@ -130,6 +130,11 @@ func (d *digest) validate() error {
 	return nil
 }
 
+// updateDigest updates the digest-string to the computed value.
+func (d *digest) updateDigest() {
+	d.hash = d.encoding.encode(d)
+}
+
 // newDigest creates a new digest from the value of a WARC digest-field or from scratch.
 //
 // digestString has the format: <algorithm>[:[<digestValue>]] where algorithm is one of md5, sha1, sha256, or sha512.

--- a/unmarshaler.go
+++ b/unmarshaler.go
@@ -23,7 +23,6 @@ import (
 	"github.com/klauspost/compress/gzip"
 	"github.com/nlnwa/gowarc/internal/countingreader"
 	"io"
-	"io/ioutil"
 )
 
 type Unmarshaler interface {
@@ -147,7 +146,7 @@ func (u *unmarshaler) Unmarshal(b *bufio.Reader) (WarcRecord, int64, *Validation
 			_ = record.block.Close()
 		}()
 
-		_, err := io.Copy(ioutil.Discard, content)
+		_, err := io.Copy(io.Discard, content)
 
 		// Discarding 4 bytes which makes up the end of record marker (\r\n\r\n)
 		b, e := r.Peek(4)


### PR DESCRIPTION
Warcfields-block is used when the WARC-records Content-Type is 'application/warc-fields', typically used in warcinfo records.