### PR TITLE
Reject directories as warc files in NewWarcFileReader

### DIFF
--- a/warcfile.go
+++ b/warcfile.go
@@ -18,6 +18,7 @@ package gowarc
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"github.com/klauspost/compress/gzip"
 	"github.com/nlnwa/gowarc/internal"
@@ -476,6 +477,14 @@ var inputBufPool = sync.Pool{
 }
 
 func NewWarcFileReader(filename string, offset int64, opts ...WarcRecordOption) (*WarcFileReader, error) {
+	info, err := os.Stat(filename)
+	if err != nil {
+		return nil, err
+	}
+	if info.IsDir() {
+		return nil, errors.New("is directory")
+	}
+
 	file, err := os.Open(filename) // For read access.
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
NewWarcFileReader accepts directories as inputs, returning a valid-ish WarcFileReader that never gives records. This caused an infinite loop for me in what I assume is a pretty common use-case:

a) Loop through all files in a directory (which in this case contains another directory)
b) Feed files to NewWarcFileReader 
c) Loop through all records in the warc, skipping over records with errors

This gives me an infinite spin loop, since the WarcFileReader exists but only ever returns error when you call .Next(). So it sees an error, goes to the "next" record, etc...

It's a bit curious that golang's file.Seek() _doesn't_ error when you give it a directory. But that's just how it works I guess. 

Seems like the cleanest solution is to have NewWarcFileReader explicitly reject directory files. Obviously this is something you could check for outside gowarc, but it'd be a cleaner experience here imo.

Thanks!